### PR TITLE
Fix: error while testing kernel >= 3.18

### DIFF
--- a/gtests/net/packetdrill/netdev.c
+++ b/gtests/net/packetdrill/netdev.c
@@ -202,7 +202,7 @@ static void set_device_offload_flags(struct local_netdev *netdev)
 {
 #ifdef linux
 	const u32 offload =
-	    TUN_F_CSUM | TUN_F_TSO4 | TUN_F_TSO6 | TUN_F_TSO_ECN | TUN_F_UFO;
+	    TUN_F_CSUM | TUN_F_TSO4 | TUN_F_TSO6 | TUN_F_TSO_ECN;
 	if (ioctl(netdev->tun_fd, TUNSETOFFLOAD, offload) != 0)
 		die_perror("TUNSETOFFLOAD");
 #endif


### PR DESCRIPTION
packetdrill exits with the following error on 3.18:
TUNSETOFFLOAD: Invalid argument

This is due to the fact that TUN_F_UFO has been removed.

Signed-off-by: Gregory Detal gregory.detal@uclouvain.be
